### PR TITLE
Add memory fixes and basic tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 PROGRAM_NAME = kagou
 CC = gcc
-CFLAGS = -g -O2 -Wall -Wextra -fsanitize=address
+CFLAGS = -g -O2 -Wall -Wextra -fsanitize=address -I./src
 SRCS = $(wildcard src/*.c)
+LIB_SRCS = $(filter-out src/main.c,$(SRCS))
 OBJS=$(SRCS:.c=.o)
+LIB_OBJS=$(LIB_SRCS:.c=.o)
 HEADERS = $(wildcard src/*.h)
 
 main: $(OBJS)
@@ -25,6 +27,16 @@ response.o: util.o src/response.c src/response.h
 util.o: src/util.c src/util.h
 	$(CC) $(CFLAGS) -c src/util.c
 
+tests/test.o: tests/test.c $(HEADERS)
+	$(CC) $(CFLAGS) -c tests/test.c -o tests/test.o
+
+tests/run_tests: $(LIB_OBJS) tests/test.o
+	$(CC) $(CFLAGS) -o tests/run_tests $(LIB_OBJS) tests/test.o
+
+.PHONY: test
+test: tests/run_tests
+	./tests/run_tests
+
 .PNONY :format
 format:
 	clang-format $(SRCS) $(HEADERS) -i
@@ -32,3 +44,4 @@ format:
 clean:
 	$(RM) kagou
 	$(RM) $(OBJS)
+	$(RM) tests/run_tests tests/test.o

--- a/src/request.c
+++ b/src/request.c
@@ -21,7 +21,13 @@ Request *Request_new(char *raw_request) {
 
 void Request_delete(Request *this) {
   free(this->raw_request);
-  free(this->request_header_values);
+  if (this->request_header_values != NULL) {
+    for (int i = 0; i < REQUEST_HEADER_ITEM_MAX_SIZE; i++) {
+      free(this->request_header_values[i].key);
+      free(this->request_header_values[i].value);
+    }
+    free(this->request_header_values);
+  }
   free(this);
 }
 
@@ -39,4 +45,5 @@ void _Request_scan(Request *this) {
   strcpy(this->request_header_values[2].key, HEADER_KEY_HTTP_VERSION);
   strcpy(this->request_header_values[2].value,
          strtok(NULL, ATTRIBUTE_DELIMITER));
+  free(cpy_message);
 }

--- a/src/request_handler.c
+++ b/src/request_handler.c
@@ -13,15 +13,13 @@ void cleanup(Request *request, Response *response, FILE *target_file) {
 }
 
 void load_text_file(Response *response, FILE *target_file) {
-  fpos_t fpos;
   fseek(target_file, 0, SEEK_END);
-  fgetpos(target_file, &fpos);
+  long fsize = ftell(target_file);
   rewind(target_file);
 
-  long fsize = sizeof(char) * (fpos + 1);
-  char *fbuf = (char *)calloc(fsize, sizeof(char));
+  char *fbuf = (char *)calloc(fsize + 1, sizeof(char));
 
-  fread(fbuf, fsize, 1, target_file);
+  fread(fbuf, 1, fsize, target_file);
   Response_set_body_as_text(response, fbuf);
   free(fbuf);
 }

--- a/src/response.c
+++ b/src/response.c
@@ -36,7 +36,7 @@ void Response_create_header(Response *this) {
   strcat(tmp_header, this->status);
   strcat(tmp_header, HEADER_LINE_BREAK_CODE);
 
-  for (int i = 0; i < (int)sizeof(this->header_values); i++) {
+  for (int i = 0; i < RESPONSE_HEADER_VALUE_SIZE; i++) {
     if (this->header_values[i].key == NULL)
       break;
     strcat(tmp_header, this->header_values[i].key);
@@ -53,6 +53,12 @@ void Response_delete(Response *this) {
   free(this->header);
   free(this->body);
   free(this->status);
-  free(this->header_values);
+  if (this->header_values != NULL) {
+    for (int i = 0; i < RESPONSE_HEADER_VALUE_SIZE; i++) {
+      free(this->header_values[i].key);
+      free(this->header_values[i].value);
+    }
+    free(this->header_values);
+  }
   free(this);
 }

--- a/src/response.c
+++ b/src/response.c
@@ -55,8 +55,11 @@ void Response_delete(Response *this) {
   free(this->status);
   if (this->header_values != NULL) {
     for (int i = 0; i < RESPONSE_HEADER_VALUE_SIZE; i++) {
+      if (this->header_values[i].key == NULL)
+        break;
       free(this->header_values[i].key);
-      free(this->header_values[i].value);
+      if (this->header_values[i].value != NULL)
+        free(this->header_values[i].value);
     }
     free(this->header_values);
   }

--- a/src/util.c
+++ b/src/util.c
@@ -25,16 +25,11 @@ extern void last_strtok(char *ret, char *target, const char *pattern) {
     return;
   }
 
-  char *last_tokenized;
   char *tokenized = strtok(target, pattern);
-  while (1) {
-    tokenized = strtok(NULL, pattern);
-    if (tokenized == NULL) {
-      break;
-    } else {
-      last_tokenized = tokenized;
-    }
+  char *last_tokenized = tokenized;
+  while ((tokenized = strtok(NULL, pattern)) != NULL) {
+    last_tokenized = tokenized;
   }
 
-  strcpy(ret, last_tokenized);
+  strcpy(ret, last_tokenized ? last_tokenized : "");
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,0 +1,29 @@
+#include "request_handler.h"
+#include "util.h"
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+static void test_content_type_from_filename() {
+    assert(strcmp(content_type_from_filename("index.html"), "text/html") == 0);
+    assert(strcmp(content_type_from_filename("style.css"), "text/css") == 0);
+    assert(strcmp(content_type_from_filename("unknown.xyz"), "text/plain") == 0);
+}
+
+static void test_last_strtok() {
+    char path1[] = "/usr/local/bin/test";
+    char last[128];
+    last_strtok(last, path1, "/");
+    assert(strcmp(last, "test") == 0);
+
+    char path2[] = "filename";
+    last_strtok(last, path2, "/");
+    assert(strcmp(last, "") == 0);
+}
+
+int main(void) {
+    test_content_type_from_filename();
+    test_last_strtok();
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- fix memory leaks in request and response handling
- correct header creation loop
- rewrite file loading for text files
- improve `last_strtok`
- add basic unit tests and new `make test` target

## Testing
- `make test`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6845667ebc8883298b5d0c38dcab2587